### PR TITLE
Larger buffer size to support Packet Mode messages

### DIFF
--- a/relay/relay.go
+++ b/relay/relay.go
@@ -105,7 +105,7 @@ func NewRelay(addr string, callsign string, targetRelays []config.TargetRelay, m
 // Listen listens for incoming packets and processes them.
 func (r *Relay) Listen(ctx context.Context, wg *sync.WaitGroup) {
 	defer wg.Done()
-	buf := make([]byte, 64)
+	buf := make([]byte, 1024)
 
 	logging.LogDebug("Relay is ready to receive packets...", nil)
 


### PR DESCRIPTION
With the existing buffer, I can send small text messages through go-m17-relay, but larger ones are truncated. Packet Mode messages can be up to 825 bytes including the CRC (section 2.7 of the spec). 